### PR TITLE
Fix | replace is working with only first

### DIFF
--- a/modules/cli/make/model/index.js
+++ b/modules/cli/make/model/index.js
@@ -60,9 +60,9 @@ module.exports = ({ args, cwd, obremapConfig }) => {
         path.join(__dirname, `/templates/${args["--how-import"]}.template`),
         "utf8"
       )
-      .replace("#__MODEL_NAME__#", modelName)
-      .replace("#__MODULE_NAME__#", moduleName)
-      .replace("#__CONFIGURATION__#", options);
+      .replaceAll("#__MODEL_NAME__#", modelName)
+      .replaceAll("#__MODULE_NAME__#", moduleName)
+      .replaceAll("#__CONFIGURATION__#", options);
 
     if (!args["--folder"])
       args["--folder"] =


### PR DESCRIPTION
previous output:
```
// THIS MODEL FILE WAS CREATED BY OBREMAP CLI
import { Model } from "@moccacoders/node-obremap";
class LessonsGroup extends Model {
  	/*
		overwrite table name, this action is optional
		static tableName = "table_name";
	*/
	
	
}
export default new #__MODEL_NAME__#();
```